### PR TITLE
Extract Data attribute from api response

### DIFF
--- a/lib/fathom_analytics/api.rb
+++ b/lib/fathom_analytics/api.rb
@@ -86,7 +86,7 @@ module FathomAnalytics
       )
 
       if response.status == 200
-        JSON.parse(response.body)
+        api_response(response.body)
       else
         raise FathomAnalytics::Error.new(response.status)
       end
@@ -104,7 +104,7 @@ module FathomAnalytics
       if response.status == 200
         yield response if block_given?
 
-        JSON.parse(response.body)
+        api_response(response.body)
       else
         raise FathomAnalytics::Error.new(response.status)
       end
@@ -121,10 +121,17 @@ module FathomAnalytics
       if response.status == 200
         yield response if block_given?
 
-        JSON.parse(response.body)
+        api_response(response.body)
       else
         raise FathomAnalytics::Error.new(response.status)
       end
+    end
+
+    def api_response(response_body)
+      parsed = JSON.parse(response_body)
+      parsed["Data"] || {}
+    rescue JSON::ParserError
+      {}
     end
 
     def ensure_auth_token

--- a/spec/fathom_analytics/api_spec.rb
+++ b/spec/fathom_analytics/api_spec.rb
@@ -44,14 +44,13 @@ RSpec.describe FathomAnalytics::Api do
       end
 
       it "returns an array of sites" do
-        expect(@sites_response).to be_an_instance_of(Hash)
-        expect(@sites_response["Data"]).to be_an_instance_of(Array)
+        expect(@sites_response).to be_an_instance_of(Array)
       end
 
       it "returns site details" do
-        expect(@sites_response["Data"].first).to have_key("id")
-        expect(@sites_response["Data"].first).to have_key("name")
-        expect(@sites_response["Data"].first).to have_key("trackingId")
+        expect(@sites_response.first).to have_key("id")
+        expect(@sites_response.first).to have_key("name")
+        expect(@sites_response.first).to have_key("trackingId")
       end
     end
 
@@ -68,17 +67,16 @@ RSpec.describe FathomAnalytics::Api do
         end
 
         it "returns an array of sites" do
-          expect(@site_response).to be_an_instance_of(Hash)
-          expect(@site_response["Data"]).to be_an_instance_of(Array)
+          expect(@site_response).to be_an_instance_of(Array)
         end
 
         it "returns site details" do
-          expect(@site_response["Data"].first).to have_key("Visitors")
-          expect(@site_response["Data"].first).to have_key("Pageviews")
-          expect(@site_response["Data"].first).to have_key("Sessions")
-          expect(@site_response["Data"].first).to have_key("BounceRate")
-          expect(@site_response["Data"].first).to have_key("AvgDuration")
-          expect(@site_response["Data"].first).to have_key("Date")
+          expect(@site_response.first).to have_key("Visitors")
+          expect(@site_response.first).to have_key("Pageviews")
+          expect(@site_response.first).to have_key("Sessions")
+          expect(@site_response.first).to have_key("BounceRate")
+          expect(@site_response.first).to have_key("AvgDuration")
+          expect(@site_response.first).to have_key("Date")
         end
       end
 
@@ -94,8 +92,7 @@ RSpec.describe FathomAnalytics::Api do
         end
 
         it "returns an empty array" do
-          expect(@site_response).to be_an_instance_of(Hash)
-          expect(@site_response["Data"]).to be_empty
+          expect(@site_response).to be_empty
         end
       end
     end


### PR DESCRIPTION
Change the return value of api methods so that we return `Data` attribute from the response. This cleans up the response on the caller side.